### PR TITLE
update command arguments support

### DIFF
--- a/sync_comment_h2s.py
+++ b/sync_comment_h2s.py
@@ -549,6 +549,6 @@ class Sh2s(object):
 
 
 if __name__ == '__main__':
-    print(sys.argv)
+    # print(sys.argv)
     sh2s = Sh2s(path=os.getcwd())
     sh2s.run()


### PR DESCRIPTION
-extension hh|cc
The default pair is h|cpp

update file comments. This program will always attempt to add "@file filename.xxx"
Use the following command to add extra comments

-fc author:Bill|date:2017.01.01

The following one will only update the file comments
-fc-only author:Bill|date:2017.01.01