### PR TITLE
update command arguments support

### DIFF
--- a/sh2s
+++ b/sh2s
@@ -1,3 +1,3 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-sudo ln -s $DIR/sync_comment_h2s.py /usr/bin/sh2s
+sudo ln -s $DIR/sync_comment_h2s.py /usr/local/bin/sh2s


### PR DESCRIPTION
-extension hh|cc
The default pair is h|cpp

update file comments. This program will always attempt to add "@file filename.xxx"
Use the following command to add extra comments

-fc author:Bill|date:2017.01.01

The following one will only update the file comments
-fc-only author:Bill|date:2017.01.01