### PR TITLE
bugfix:

### DIFF
--- a/sync_comment_h2s.py
+++ b/sync_comment_h2s.py
@@ -358,6 +358,7 @@ class Sh2s(object):
             :param string: a line of code
             """
             in_string = ""
+            in_parentheses = []
             for s in string:
                 if not in_string:
                     if s == '"' or s == "'":
@@ -367,6 +368,16 @@ class Sh2s(object):
                     if s == in_string:
                         in_string = ''
                     continue
+
+                if not in_parentheses:
+                    if s == '(':
+                        in_parentheses.append(s)
+                        continue
+                else:
+                    if s == ')':
+                        in_parentheses.pop()
+                    continue
+
                 if '{' == s:
                     is_in_function.append('{')
                 elif '}' == s:


### PR DESCRIPTION
    deal with class forward declaration
    replace tabs with four space.
    extra function name bugs
    '}' in string caused problem.
    '}' in () caused problem.
    match_function_name to be a  function